### PR TITLE
add /query route

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'json'
 gem 'jsonatra'
 gem 'httpclient'
 gem 'pg'
+gem 'sequel'
 gem 'logger'
 
 gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,15 +9,16 @@ GEM
     logger (1.2.8)
     method_source (0.8.2)
     pg (0.17.0)
-    pry (0.9.12.3)
+    pry (0.9.12.4)
       coderay (~> 1.0)
       method_source (~> 0.8)
       slop (~> 3.4)
-    puma (2.6.0)
+    puma (2.7.0)
       rack (>= 1.1, < 2.0)
     rack (1.5.2)
     rack-protection (1.5.1)
       rack
+    sequel (4.5.0)
     shotgun (0.9)
       rack (>= 1.0)
     sinatra (1.4.4)
@@ -38,5 +39,6 @@ DEPENDENCIES
   pg
   pry
   puma
+  sequel
   shotgun
   sinatra

--- a/README.md
+++ b/README.md
@@ -50,8 +50,51 @@ After you've gathered some aggregates of these counts, send the total for each c
 combination in a POST request to the `/report` endpoint. The existing count for the day will be updated
 with the value of `number` provided.
 
+`GET /query`
 
+* keys - List<String>, required
+* value - String, optional
+* client_id - String, optional
+* from - YYYMMDD, optional
+* to - YYYMMDD, optional
 
+The `client_id` parameter filters by client. It can be omitted if you want global usage.
+
+The `keys` parameter filters by one or more keys.
+
+The `value` parameter can only be used for filtering if only a single key is provided.
+
+The `from` and `to` parameters can be used to filter by a date range (inclusive).
+
+Example queries:
+* **/query?client_id=1234&key=device-os&value=android&from=20130101&to=20131225** android usage for a date range
+* **/query?key=client-name** global client usage by day
+
+Results will be returned in the following format, ordered by date (ascending):
+
+```javascript
+// GET /query?keys=test_key,another_test_key
+[
+    {
+        "another_test_key": {
+            "additional_test_value": 23
+        },
+        "date": "2013-12-08"
+    },
+    {
+        "another_test_key": {
+            "additional_test_value": 23,
+            "another_test_value": 3,
+            "test_value": 19
+        },
+        "date": "2013-12-09",
+        "test_key": {
+            "another_test_value": 9000,
+            "test_value": 2
+        }
+    }
+]
+```
 
 Android
 -------

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ require './env.rb'
 
 namespace :db do
   task :setup do
-    DB.create_table :stats do
+    SQL.create_table :stats do
       primary_key [:client_id, :date, :key, :value]
       String :client_id
       DateTime :date

--- a/env.rb
+++ b/env.rb
@@ -8,8 +8,15 @@ require 'yaml'
 SiteConfig = YAML.load_file('config.yml')
 
 DB = PG.connect({ 
-  :host => SiteConfig['db']['host'],
-  :port => SiteConfig['db']['port'], 
-  :user => SiteConfig['db']['user'],
-  :dbname => SiteConfig['db']['name']
+  host: SiteConfig['db']['host'],
+  port: SiteConfig['db']['port'],
+  user: SiteConfig['db']['user'],
+  dbname: SiteConfig['db']['name']
 })
+
+db_url = "postgres://%s@%s:%d/%s" % [
+    SiteConfig['db']['user'], SiteConfig['db']['host'], SiteConfig['db']['port'], SiteConfig['db']['name']
+]
+SQL = Sequel.connect(db_url)
+
+STATS = SQL[:stats]


### PR DESCRIPTION
This changeset adds a `/query` GET route which accepts the following parameters:
- keys
- value 
- from
- to
- client_id

Results are returned in the format:

```
[
    {
        "date": "2013-12-08",
        "key": {
            "value": 42
        }
    }
]
```
